### PR TITLE
Don't wrap the overridden element with a container

### DIFF
--- a/dist/pikaday-package.js
+++ b/dist/pikaday-package.js
@@ -1,14 +1,14 @@
 
- /* 
- * PikadayResponsive 
- * A responsive datepicker built on top of Pikaday. It shows the native datepicker on mobile devices and a nice JS-picker on desktop. 
- * 
- * @author: Francesco Novy 
- * @licence: MIT <http://www.opensource.org/licenses/mit-license.php> 
- * @link https://github.com/mydea/PikadayResponsive 
- * @copyright: (c) 2016 
- * @version: 0.7.0 
- */ 
+ /*
+ * PikadayResponsive
+ * A responsive datepicker built on top of Pikaday. It shows the native datepicker on mobile devices and a nice JS-picker on desktop.
+ *
+ * @author: Francesco Novy
+ * @licence: MIT <http://www.opensource.org/licenses/mit-license.php>
+ * @link https://github.com/mydea/PikadayResponsive
+ * @copyright: (c) 2016
+ * @version: 0.7.0
+ */
 
 //! moment.js
 //! version : 2.14.1
@@ -5291,16 +5291,16 @@
 }));
 
 
- /* 
- * PikadayResponsive 
- * A responsive datepicker built on top of Pikaday. It shows the native datepicker on mobile devices and a nice JS-picker on desktop. 
- * 
- * @author: Francesco Novy 
- * @licence: MIT <http://www.opensource.org/licenses/mit-license.php> 
- * @link https://github.com/mydea/PikadayResponsive 
- * @copyright: (c) 2016 
- * @version: 0.7.0 
- */ 
+ /*
+ * PikadayResponsive
+ * A responsive datepicker built on top of Pikaday. It shows the native datepicker on mobile devices and a nice JS-picker on desktop.
+ *
+ * @author: Francesco Novy
+ * @licence: MIT <http://www.opensource.org/licenses/mit-license.php>
+ * @link https://github.com/mydea/PikadayResponsive
+ * @copyright: (c) 2016
+ * @version: 0.7.0
+ */
 
 (function(root, factory) {
   if (typeof define === 'function') {
@@ -5346,8 +5346,6 @@
     var $el = $(el);
     var settings = $.extend({}, defaultOptions, options);
 
-    // The container element for the input
-    var $container;
     // The actual input field
     var $input;
     // The display input field
@@ -5368,9 +5366,6 @@
 
     // The original input field is made hidden. This field will contain the actual value.
     $el.attr("type", "hidden");
-    // Wrap the input in a container
-    $el.wrap("<span class='pikaday__container'></span>");
-    $container = $el.parent(".pikaday__container");
 
     // If the original input has an ID, use it to generate IDs for the generated display inputs
     var originalId = $el.attr('id');
@@ -5381,10 +5376,10 @@
       if (originalId) {
         $input.attr('id', originalId + '-input');
       }
-      $container.append($input);
+      $el.after($input);
 
       $display = $("<input type='text' readonly='readonly' class='pikaday__display pikaday__display--native " + settings.classes + "' placeholder='" + settings.placeholder + "' />");
-      $container.append($display);
+      $el.after($display);
 
       $input.on("change", function() {
         var val = $(this).val();
@@ -5421,7 +5416,7 @@
       if (originalId) {
         $input.attr('id', originalId + '-input');
       }
-      $container.append($input);
+      $el.after($input);
 
       var hasSelected = false;
       var selectTimer = null;

--- a/dist/pikaday-responsive.js
+++ b/dist/pikaday-responsive.js
@@ -1,14 +1,14 @@
 
- /* 
- * PikadayResponsive 
- * A responsive datepicker built on top of Pikaday. It shows the native datepicker on mobile devices and a nice JS-picker on desktop. 
- * 
- * @author: Francesco Novy 
- * @licence: MIT <http://www.opensource.org/licenses/mit-license.php> 
- * @link https://github.com/mydea/PikadayResponsive 
- * @copyright: (c) 2016 
- * @version: 0.7.0 
- */ 
+ /*
+ * PikadayResponsive
+ * A responsive datepicker built on top of Pikaday. It shows the native datepicker on mobile devices and a nice JS-picker on desktop.
+ *
+ * @author: Francesco Novy
+ * @licence: MIT <http://www.opensource.org/licenses/mit-license.php>
+ * @link https://github.com/mydea/PikadayResponsive
+ * @copyright: (c) 2016
+ * @version: 0.7.0
+ */
 
 (function(root, factory) {
   if (typeof define === 'function') {
@@ -54,8 +54,6 @@
     var $el = $(el);
     var settings = $.extend({}, defaultOptions, options);
 
-    // The container element for the input
-    var $container;
     // The actual input field
     var $input;
     // The display input field
@@ -76,9 +74,6 @@
 
     // The original input field is made hidden. This field will contain the actual value.
     $el.attr("type", "hidden");
-    // Wrap the input in a container
-    $el.wrap("<span class='pikaday__container'></span>");
-    $container = $el.parent(".pikaday__container");
 
     // If the original input has an ID, use it to generate IDs for the generated display inputs
     var originalId = $el.attr('id');
@@ -89,10 +84,10 @@
       if (originalId) {
         $input.attr('id', originalId + '-input');
       }
-      $container.append($input);
+      $el.after($input);
 
       $display = $("<input type='text' readonly='readonly' class='pikaday__display pikaday__display--native " + settings.classes + "' placeholder='" + settings.placeholder + "' />");
-      $container.append($display);
+      $el.after($display);
 
       $input.on("change", function() {
         var val = $(this).val();
@@ -129,7 +124,7 @@
       if (originalId) {
         $input.attr('id', originalId + '-input');
       }
-      $container.append($input);
+      $el.after($input);
 
       var hasSelected = false;
       var selectTimer = null;

--- a/src/pikaday-responsive.js
+++ b/src/pikaday-responsive.js
@@ -42,8 +42,6 @@
     var $el = $(el);
     var settings = $.extend({}, defaultOptions, options);
 
-    // The container element for the input
-    var $container;
     // The actual input field
     var $input;
     // The display input field
@@ -64,9 +62,6 @@
 
     // The original input field is made hidden. This field will contain the actual value.
     $el.attr("type", "hidden");
-    // Wrap the input in a container
-    $el.wrap("<span class='pikaday__container'></span>");
-    $container = $el.parent(".pikaday__container");
 
     // If the original input has an ID, use it to generate IDs for the generated display inputs
     var originalId = $el.attr('id');
@@ -77,10 +72,10 @@
       if (originalId) {
         $input.attr('id', originalId + '-input');
       }
-      $container.append($input);
+      $el.after($input);
 
       $display = $("<input type='text' readonly='readonly' class='pikaday__display pikaday__display--native " + settings.classes + "' placeholder='" + settings.placeholder + "' />");
-      $container.append($display);
+      $el.after($display);
 
       $input.on("change", function() {
         var val = $(this).val();
@@ -117,7 +112,7 @@
       if (originalId) {
         $input.attr('id', originalId + '-input');
       }
-      $container.append($input);
+      $el.after($input);
 
       var hasSelected = false;
       var selectTimer = null;


### PR DESCRIPTION
The current code is wrapping the original input and the generated input
with a container `span`. The wrapper causes problems with inputs that
use :focus to, e.g., change the underline border color or animate moving
placeholder text via CSS. This can only be done with javascript without
having the input as a sibling except in the trivial case where there is only
one input on the page.