### PR TITLE
Allow custom attributes to be added to the input.

### DIFF
--- a/dist/pikaday-package.js
+++ b/dist/pikaday-package.js
@@ -5339,7 +5339,8 @@
     classes: "",
     placeholder: "Select a date",
     pikadayOptions: {},
-    dayOffset: 0
+    dayOffset: 0,
+    attributes: ""
   };
 
   return function(el, options) {
@@ -5383,7 +5384,7 @@
       }
       $container.append($input);
 
-      $display = $("<input type='text' readonly='readonly' class='pikaday__display pikaday__display--native " + settings.classes + "' placeholder='" + settings.placeholder + "' />");
+      $display = $("<input type='text' readonly='readonly' class='pikaday__display pikaday__display--native " + settings.classes + "' placeholder='" + settings.placeholder + "' " + settings.attributes + "/>");
       $container.append($display);
 
       $input.on("change", function() {
@@ -5417,7 +5418,7 @@
 
     } else {
       // Use Pikaday
-      $input = $("<input type='text' class='pikaday__display pikaday__display--pikaday " + settings.classes + "' placeholder='" + settings.placeholder + "' />");
+      $input = $("<input type='text' class='pikaday__display pikaday__display--pikaday " + settings.classes + "' placeholder='" + settings.placeholder + "' " + settings.attributes + "/>");
       if (originalId) {
         $input.attr('id', originalId + '-input');
       }

--- a/dist/pikaday-responsive.js
+++ b/dist/pikaday-responsive.js
@@ -47,7 +47,8 @@
     classes: "",
     placeholder: "Select a date",
     pikadayOptions: {},
-    dayOffset: 0
+    dayOffset: 0,
+    attributes: ""
   };
 
   return function(el, options) {
@@ -91,7 +92,7 @@
       }
       $container.append($input);
 
-      $display = $("<input type='text' readonly='readonly' class='pikaday__display pikaday__display--native " + settings.classes + "' placeholder='" + settings.placeholder + "' />");
+      $display = $("<input type='text' readonly='readonly' class='pikaday__display pikaday__display--native " + settings.classes + "' placeholder='" + settings.placeholder + "' " + settings.attributes + "/>");
       $container.append($display);
 
       $input.on("change", function() {
@@ -125,7 +126,7 @@
 
     } else {
       // Use Pikaday
-      $input = $("<input type='text' class='pikaday__display pikaday__display--pikaday " + settings.classes + "' placeholder='" + settings.placeholder + "' />");
+      $input = $("<input type='text' class='pikaday__display pikaday__display--pikaday " + settings.classes + "' placeholder='" + settings.placeholder + "' " + settings.attributes + "/>");
       if (originalId) {
         $input.attr('id', originalId + '-input');
       }

--- a/src/pikaday-responsive.js
+++ b/src/pikaday-responsive.js
@@ -35,7 +35,8 @@
     classes: "",
     placeholder: "Select a date",
     pikadayOptions: {},
-    dayOffset: 0
+    dayOffset: 0,
+    attributes: ""
   };
 
   return function(el, options) {
@@ -79,7 +80,7 @@
       }
       $container.append($input);
 
-      $display = $("<input type='text' readonly='readonly' class='pikaday__display pikaday__display--native " + settings.classes + "' placeholder='" + settings.placeholder + "' />");
+      $display = $("<input type='text' readonly='readonly' class='pikaday__display pikaday__display--native " + settings.classes + "' placeholder='" + settings.placeholder + "' " + settings.attributes + "/>");
       $container.append($display);
 
       $input.on("change", function() {
@@ -113,7 +114,7 @@
 
     } else {
       // Use Pikaday
-      $input = $("<input type='text' class='pikaday__display pikaday__display--pikaday " + settings.classes + "' placeholder='" + settings.placeholder + "' />");
+      $input = $("<input type='text' class='pikaday__display pikaday__display--pikaday " + settings.classes + "' placeholder='" + settings.placeholder + "' " + settings.attributes + "/>");
       if (originalId) {
         $input.attr('id', originalId + '-input');
       }


### PR DESCRIPTION
The current code is wrapping the original input and the generated input
with a container `span`. The wrapper causes problems with inputs that
use :focus to, e.g., change the underline border color or animate moving
placeholder text via CSS. This can only be done with javascript without
having the input as a sibling except in the trivial case where there is only
one input on the page.

NOTE: @Vallevard originally did this in issue #18. I just thought it might
be more likely to make it into the base repo is you saw it as a PR. This
specifically solves a problem I was having where I need `required` on
my input for CSS animated placeholders to work properly.